### PR TITLE
fixed issue where studio drivers were found instead of game ready

### DIFF
--- a/NVUpdateManager.Web/UpdateFinder.cs
+++ b/NVUpdateManager.Web/UpdateFinder.cs
@@ -42,7 +42,9 @@ namespace NVUpdateManager.Web
 
             var updateTable = parser.ParseDocument(html);
 
-            var latestDriver = updateTable.All.First(x => x.Id == "driverList");
+            var latestDriver = updateTable.All.First(
+                x => x.Id == "driverList"
+                && x.QuerySelector("a").TextContent.Contains("Game Ready Driver"));
 
             var result = "https:";
             result += latestDriver.QuerySelector("a").GetAttribute("href");


### PR DESCRIPTION
The order of the table of updates changed to where the studio update was first. This fix ensures that the driver presented for update is a game ready driver