### PR TITLE
Fixed to work with the new NVIDIA site design

### DIFF
--- a/.github/workflows/dotnet-deploy.yml
+++ b/.github/workflows/dotnet-deploy.yml
@@ -5,83 +5,33 @@ name: .NET Deploy
 
 on:
   push:
-    branches: [ "main" ]
     tags:
       - '*'
 
 jobs:
         
-  build:
+  build-and-release:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build NotificationService project
         run: dotnet build -c Release --no-restore
       - name: Compress archive
         run: Compress-Archive -Path .\NVUpdateManager.NotificationService\bin\Release\* -DestinationPath .\NVUpdateManager.NotificationService.zip -CompressionLevel Fastest
-      - name: Upload zip file
-        uses: actions/upload-artifact@v3
+      - name: Generate Release Notes
+        run: git log -1 --pretty=%B > ${{ github.workspace }}-CHANGELOG.txt
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
         with:
-          name: artifact
-          path: NVUpdateManager.NotificationService.zip
-          
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-    steps:
-    - uses: actions/checkout@v3
-      with:
-          fetch-depth: 0
-    - name: Increment Commit Tag
-      id: version-tag
-      run: |
-        current_tag=$(git describe --abbrev=0 --tags)
-        echo current tag: $current_tag
-        major=$(echo $current_tag | cut -d "." -f 1 | cut -d "v" -f 2)
-        minor=$(echo $current_tag | cut -d "." -f 2)
-        new_minor=$((minor + 1))
-        release_tag="v$major.$new_minor"
-        git tag $release_tag
-        git push --tags
-        echo "RELEASE_TAG=$release_tag" >> $GITHUB_OUTPUT
-
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.version-tag.outputs.release_tag }}
-        release_name: Release ${{ steps.version-tag.outputs.release_tag }}
-        draft: false
-        prerelease: false
-          
-  upload-release-artifact:
-    needs: 
-    - build
-    - release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download release artifact
-        uses: actions/download-artifact@v4.1.7
-        with:
-          name: artifact
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./NVUpdateManager.NotificationService.zip
-          asset_name: NVUpdateManager.NotificationService.zip
-          asset_content_type: application/zip
-          
+          body_path: ${{ github.workspace }}-CHANGELOG.txt
+          files: |
+            README.md
+            LICENSE
+            NVUpdateManager.NotificationService.zip
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/NVUpdateManager.Core/GlobalSuppressions.cs
+++ b/NVUpdateManager.Core/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "This program only ships on Windows", Scope = "module")]

--- a/NVUpdateManager.EmailHandler/EmailHandler.cs
+++ b/NVUpdateManager.EmailHandler/EmailHandler.cs
@@ -45,9 +45,9 @@ namespace NVUpdateManager.EmailHandler
             // Create a new instance of the RNGCryptoServiceProvider.
             // Fill the array with a random value.
 
-            using (var rngCSP = new RNGCryptoServiceProvider())
+            using (var rng = RandomNumberGenerator.Create())
             {
-                rngCSP.GetBytes(entropy);
+                rng.GetBytes(entropy);
             }
 
             byte[] encryptedData = ProtectedData.Protect(toEncrypt, entropy, DataProtectionScope.LocalMachine);

--- a/NVUpdateManager.EmailHandler/GlobalSuppressions.cs
+++ b/NVUpdateManager.EmailHandler/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "This program only ships on Windows", Scope = "module")]

--- a/NVUpdateManager.NotificationService/Services/NVNotificationService.cs
+++ b/NVUpdateManager.NotificationService/Services/NVNotificationService.cs
@@ -14,7 +14,6 @@ namespace NVUpdateManager.NotificationService.Services
         private readonly IEnumerable<SupportedDriver> _supportedDrivers;
         private readonly IDriverManager _driverManager;
         private readonly IUpdateFinder _updateFinder;
-        private const double ITERATION_TIME_IN_HOURS = 24; // Time between checks for updates
 
         public NVNotificationService(ILogger<NVNotificationService> logger, IOptions<EmailConfiguration> options, IEnumerable<SupportedDriver> supportedDrivers, IDriverManager driverManager, IUpdateFinder updateFinder)
         {

--- a/NVUpdateManager.NotificationService/appsettings.json
+++ b/NVUpdateManager.NotificationService/appsettings.json
@@ -34,6 +34,12 @@
       "DriverType": "GeForce",
       "SearchName": "GeForce RTX 4090",
       "WmiName": "NVIDIA GeForce RTX 4090"
+    },
+    {
+      "DriverSeries": "GeForce RTX 40 Series",
+      "DriverType": "GeForce",
+      "SearchName": "GeForce RTX 4070",
+      "WmiName": "NVIDIA GeForce RTX 4070"
     }
   ]
 }

--- a/NVUpdateManager.Web/Data/NvidiaDriverLookupInfo.cs
+++ b/NVUpdateManager.Web/Data/NvidiaDriverLookupInfo.cs
@@ -28,7 +28,8 @@ namespace NVUpdateManager.Web.Data
             {
                 { "GeForce RTX 3080", 929 },
                 { "GeForce RTX 4090", 995 },
-                { "GeForce GTX 1660 SUPER", 910 }
+                { "GeForce GTX 1660 SUPER", 910 },
+                { "GeForce RTX 4070", 1015 }
             };
         }
 


### PR DESCRIPTION
# Problem

The site's design was changed to a flow like this:

- User provides GPU and OS info
- A new API call is made with a driver download ID parameter to fetch the details of the update for both the studio and Game Ready drivers
- A pre-loaded HTML template is filled in with the details and rendered
- The user selects either the Game Ready or Studio driver and is then taken to the actual download page

# Changes

- `UpdateFinder` mimics this flow by calling the original API to get the list of updates for the GPU, and using the update number to call the new API to get the details
- Parsing less HTML since the new details API call returns JSON :)
- Added support for RTX 4070

# Misc

- Fixed obsolete .NET API calls
- Suppressed platform warnings 
